### PR TITLE
style: removed rowGap as it is not supported in some browsers

### DIFF
--- a/src/components/FileNotFound.tsx
+++ b/src/components/FileNotFound.tsx
@@ -1,35 +1,15 @@
 import type { ReactElement } from 'react'
 import Typography from '@material-ui/core/Typography'
-import Paper from '@material-ui/core/Paper'
-import { makeStyles, Theme, createStyles } from '@material-ui/core/styles'
 import { Wind } from 'react-feather'
 import text from '../translations'
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      width: '100%',
-      padding: theme.spacing(2),
-      paddingTop: theme.spacing(6),
-      paddingBottom: theme.spacing(6),
-      display: 'flex',
-      flexDirection: 'column',
-      rowGap: theme.spacing(2),
-      alignItems: 'center',
-      textAlign: 'center',
-      justifyContent: 'space-between',
-    },
-  }),
-)
+import LayoutContent from './LayoutContent'
 
 export default function FileNotFound(): ReactElement {
-  const classes = useStyles()
-
   return (
-    <Paper square elevation={0} className={classes.root}>
+    <LayoutContent>
       <Wind size={48} strokeWidth={0.5} />
       <Typography variant="subtitle1">{text.fileNotFound.header}</Typography>
       <Typography variant="body2">{text.fileNotFound.description}</Typography>
-    </Paper>
+    </LayoutContent>
   )
 }

--- a/src/components/InvalidSwarmHash.tsx
+++ b/src/components/InvalidSwarmHash.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react'
 import Typography from '@material-ui/core/Typography'
-import Paper from '@material-ui/core/Paper'
 import { AlertOctagon } from 'react-feather'
 import text from '../translations'
 import LayoutContent from './LayoutContent'

--- a/src/components/InvalidSwarmHash.tsx
+++ b/src/components/InvalidSwarmHash.tsx
@@ -1,35 +1,16 @@
 import type { ReactElement } from 'react'
 import Typography from '@material-ui/core/Typography'
 import Paper from '@material-ui/core/Paper'
-import { makeStyles, Theme, createStyles } from '@material-ui/core/styles'
 import { AlertOctagon } from 'react-feather'
 import text from '../translations'
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      width: '100%',
-      padding: theme.spacing(2),
-      paddingTop: theme.spacing(6),
-      paddingBottom: theme.spacing(6),
-      display: 'flex',
-      flexDirection: 'column',
-      rowGap: theme.spacing(2),
-      alignItems: 'center',
-      textAlign: 'center',
-      justifyContent: 'space-between',
-    },
-  }),
-)
+import LayoutContent from './LayoutContent'
 
 export default function InvalidSwarmHash(): ReactElement {
-  const classes = useStyles()
-
   return (
-    <Paper square elevation={0} className={classes.root}>
+    <LayoutContent>
       <AlertOctagon size={48} strokeWidth={0.5} />
       <Typography variant="subtitle1">{text.invalidSwarmHash.header}</Typography>
       <Typography variant="body2">{text.invalidSwarmHash.description}</Typography>
-    </Paper>
+    </LayoutContent>
   )
 }

--- a/src/components/LayoutContent.tsx
+++ b/src/components/LayoutContent.tsx
@@ -1,0 +1,41 @@
+import type { ReactElement } from 'react'
+import Paper from '@material-ui/core/Paper'
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles'
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      width: '100%',
+      padding: theme.spacing(2),
+      paddingTop: theme.spacing(6),
+      paddingBottom: theme.spacing(6),
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      textAlign: 'center',
+      justifyContent: 'space-between',
+    },
+    item: {
+      marginTop: theme.spacing(1),
+      marginBottom: theme.spacing(1),
+    },
+  }),
+)
+
+interface Props {
+  children: ReactElement[]
+}
+
+export default function LayoutContent({ children }: Props): ReactElement {
+  const classes = useStyles()
+
+  return (
+    <Paper square elevation={0} className={classes.root}>
+      {children.map((child, i) => (
+        <div key={i} className={classes.item}>
+          {child}
+        </div>
+      ))}
+    </Paper>
+  )
+}

--- a/src/components/LoadingFile.tsx
+++ b/src/components/LoadingFile.tsx
@@ -1,36 +1,16 @@
 import type { ReactElement } from 'react'
 import Typography from '@material-ui/core/Typography'
-import Paper from '@material-ui/core/Paper'
-import { makeStyles, Theme, createStyles } from '@material-ui/core/styles'
 import CircularProgress from '@material-ui/core/CircularProgress'
 
 import text from '../translations'
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      width: '100%',
-      padding: theme.spacing(2),
-      paddingTop: theme.spacing(6),
-      paddingBottom: theme.spacing(6),
-      display: 'flex',
-      flexDirection: 'column',
-      rowGap: theme.spacing(2),
-      alignItems: 'center',
-      textAlign: 'center',
-      justifyContent: 'space-between',
-    },
-  }),
-)
+import LayoutContent from './LayoutContent'
 
 export default function LoadingFile(): ReactElement {
-  const classes = useStyles()
-
   return (
-    <Paper square elevation={0} className={classes.root}>
+    <LayoutContent>
       <CircularProgress size={48} color="inherit" thickness={1} />
       <Typography variant="subtitle1">{text.loadingFile.header}</Typography>
       <Typography variant="body2">{text.loadingFile.description}</Typography>
-    </Paper>
+    </LayoutContent>
   )
 }

--- a/src/components/UnknownFile.tsx
+++ b/src/components/UnknownFile.tsx
@@ -1,35 +1,15 @@
 import type { ReactElement } from 'react'
 import Typography from '@material-ui/core/Typography'
-import Paper from '@material-ui/core/Paper'
-import { makeStyles, Theme, createStyles } from '@material-ui/core/styles'
 import { AlertOctagon } from 'react-feather'
 import text from '../translations'
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      width: '100%',
-      padding: theme.spacing(2),
-      paddingTop: theme.spacing(6),
-      paddingBottom: theme.spacing(6),
-      display: 'flex',
-      flexDirection: 'column',
-      rowGap: theme.spacing(2),
-      alignItems: 'center',
-      textAlign: 'center',
-      justifyContent: 'space-between',
-    },
-  }),
-)
+import LayoutContent from './LayoutContent'
 
 export default function UnknownFile(): ReactElement {
-  const classes = useStyles()
-
   return (
-    <Paper square elevation={0} className={classes.root}>
+    <LayoutContent>
       <AlertOctagon size={48} strokeWidth={0.5} />
       <Typography variant="subtitle1">{text.unknownFile.header}</Typography>
       <Typography variant="body2">{text.unknownFile.description}</Typography>
-    </Paper>
+    </LayoutContent>
   )
 }


### PR DESCRIPTION
resolves: #67 

Using rowGap in browsers with flexbox has limited support. See https://learn.coderslang.com/0046-css-flexbox-gap/#whats-the-catch

> ### What’s the catch?
> The use of this property for flex containers is currently limited. At the time of this writing, only 68% of browsers support this property. This is quite small for a widespread use of the flexbox gap, but hopefully this changes soon.
