### PR TITLE
feat: node index by hash

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,6 @@
 import { Reference } from '@ethersphere/bee-js'
 
-export const DOWNLOAD_HOST = process.env.REACT_APP_BEE_DOWNLOAD_API || 'http://localhost:1633'
-export const UPLOAD_HOSTS: string[] = process.env.REACT_APP_BEE_UPLOAD_APIS?.split(',') || ['http://localhost:1633']
+export const BEE_HOSTS: string[] = process.env.REACT_APP_BEE_HOSTS?.split(',') || ['http://localhost:1633']
 export const POSTAGE_STAMP =
   (process.env.REACT_APP_POSTAGE_STAMP as Reference | undefined) ||
   ('0000000000000000000000000000000000000000000000000000000000000000' as Reference)

--- a/src/pages/AccessHash.tsx
+++ b/src/pages/AccessHash.tsx
@@ -17,7 +17,6 @@ import LoadingFile from '../components/LoadingFile'
 import InvalidSwarmHash from '../components/InvalidSwarmHash'
 
 import { Context } from '../providers/bee'
-import { DOWNLOAD_HOST } from '../constants'
 
 import text from '../translations'
 
@@ -35,7 +34,7 @@ const SharePage = (): ReactElement => {
   const classes = useStyles()
 
   const { hash } = useParams<{ hash: string }>()
-  const { getMetadata, getPreview, getChunk } = useContext(Context)
+  const { getMetadata, getPreview, getChunk, getDownloadLink } = useContext(Context)
   const [metadata, setMetadata] = useState<Metadata | undefined>()
   const [preview, setPreview] = useState<string | undefined>(undefined)
   const [isLoading, setIsLoading] = useState<boolean>(true)
@@ -119,7 +118,7 @@ const SharePage = (): ReactElement => {
               variant="contained"
               className={classes.button}
               size="large"
-              href={`${DOWNLOAD_HOST}/bzz/${hash}`}
+              href={getDownloadLink(hash)}
               target="_blank"
             >
               <ArrowDown />
@@ -151,7 +150,7 @@ const SharePage = (): ReactElement => {
               variant="contained"
               className={classes.button}
               size="large"
-              href={`${DOWNLOAD_HOST}/bzz/${hash}`}
+              href={getDownloadLink(hash)}
               target="_blank"
             >
               <ArrowDown />

--- a/src/providers/bee.tsx
+++ b/src/providers/bee.tsx
@@ -1,10 +1,9 @@
-import { createContext, ReactChild, ReactElement, useEffect, useState } from 'react'
+import { createContext, ReactChild, ReactElement } from 'react'
 import { Bee, Data, FileData, Reference } from '@ethersphere/bee-js'
-import { UPLOAD_HOSTS, META_FILE_NAME, POSTAGE_STAMP, DOWNLOAD_HOST, PREVIEW_FILE_NAME } from '../constants'
+import { BEE_HOSTS, META_FILE_NAME, POSTAGE_STAMP, PREVIEW_FILE_NAME } from '../constants'
 
-const randomHost = UPLOAD_HOSTS[Math.floor(Math.random() * UPLOAD_HOSTS.length)]
-const bee = new Bee(randomHost)
-const beeGateway = new Bee(DOWNLOAD_HOST)
+const randomIndex = Math.floor(Math.random() * BEE_HOSTS.length)
+const randomBee = new Bee(BEE_HOSTS[randomIndex])
 
 interface ContextInterface {
   isConnected: boolean
@@ -12,14 +11,16 @@ interface ContextInterface {
   getMetadata: (hash: Reference | string) => Promise<Metadata | undefined>
   getPreview: (hash: Reference | string) => Promise<FileData<Data>>
   getChunk: (hash: Reference | string) => Promise<Data>
+  getDownloadLink: (hash: Reference | string) => string
 }
 
 const initialValues: ContextInterface = {
-  isConnected: false,
+  isConnected: true,
   upload: () => Promise.reject(),
   getMetadata: () => Promise.reject(),
   getPreview: () => Promise.reject(),
   getChunk: () => Promise.reject(),
+  getDownloadLink: () => '',
 }
 
 export const Context = createContext<ContextInterface>(initialValues)
@@ -29,10 +30,14 @@ interface Props {
   children: ReactChild
 }
 
-export function Provider({ children }: Props): ReactElement {
-  const [isConnected, setIsConnected] = useState<boolean>(false)
+function hashToIndex(hash: Reference | string) {
+  const n = parseInt(hash.slice(0, 8), 16)
 
-  const upload = (file: File, preview?: Blob) => {
+  return n % BEE_HOSTS.length
+}
+
+export function Provider({ children }: Props): ReactElement {
+  const upload = async (file: File, preview?: Blob) => {
     const metadata = {
       name: file.name,
       type: file.type,
@@ -47,12 +52,22 @@ export function Provider({ children }: Props): ReactElement {
 
     if (preview) files.push(new File([preview], PREVIEW_FILE_NAME))
 
-    return bee.uploadFiles(POSTAGE_STAMP, files, { indexDocument: metadata.name })
+    const hash = await randomBee.uploadFiles(POSTAGE_STAMP, files, { indexDocument: metadata.name })
+    const hashIndex = hashToIndex(hash)
+
+    if (hashIndex !== randomIndex) {
+      const bee = new Bee(BEE_HOSTS[hashIndex])
+      await bee.uploadFiles(POSTAGE_STAMP, files, { indexDocument: metadata.name })
+    }
+
+    return hash
   }
 
   const getMetadata = async (hash: Reference | string): Promise<Metadata | undefined> => {
     try {
-      const metadata = await beeGateway.downloadFile(hash, META_FILE_NAME)
+      const hashIndex = hashToIndex(hash)
+      const bee = new Bee(BEE_HOSTS[hashIndex])
+      const metadata = await bee.downloadFile(hash, META_FILE_NAME)
 
       return JSON.parse(metadata.data.text()) as Metadata
     } catch (e) {
@@ -60,16 +75,31 @@ export function Provider({ children }: Props): ReactElement {
     }
   }
 
-  const getPreview = (hash: Reference | string): Promise<FileData<Data>> =>
-    beeGateway.downloadFile(hash, PREVIEW_FILE_NAME)
+  const getPreview = (hash: Reference | string): Promise<FileData<Data>> => {
+    const hashIndex = hashToIndex(hash)
+    const bee = new Bee(BEE_HOSTS[hashIndex])
 
-  const getChunk = (hash: Reference | string): Promise<Data> => beeGateway.downloadData(hash)
+    return bee.downloadFile(hash, PREVIEW_FILE_NAME)
+  }
 
-  useEffect(() => {
-    bee.isConnected().then(setIsConnected)
-  }, [])
+  const getChunk = (hash: Reference | string): Promise<Data> => {
+    const hashIndex = hashToIndex(hash)
+    const bee = new Bee(BEE_HOSTS[hashIndex])
+
+    return bee.downloadData(hash)
+  }
+
+  const getDownloadLink = (hash: Reference | string) => {
+    const hashIndex = hashToIndex(hash)
+
+    return `${BEE_HOSTS[hashIndex]}/bzz/${hash}`
+  }
+
+  const isConnected = true
 
   return (
-    <Context.Provider value={{ getMetadata, isConnected, upload, getPreview, getChunk }}>{children}</Context.Provider>
+    <Context.Provider value={{ getMetadata, isConnected, upload, getPreview, getChunk, getDownloadLink }}>
+      {children}
+    </Context.Provider>
   )
 }

--- a/src/providers/bee.tsx
+++ b/src/providers/bee.tsx
@@ -6,7 +6,6 @@ const randomIndex = Math.floor(Math.random() * BEE_HOSTS.length)
 const randomBee = new Bee(BEE_HOSTS[randomIndex])
 
 interface ContextInterface {
-  isConnected: boolean
   upload: (file: File, preview?: Blob) => Promise<Reference>
   getMetadata: (hash: Reference | string) => Promise<Metadata | undefined>
   getPreview: (hash: Reference | string) => Promise<FileData<Data>>
@@ -15,7 +14,6 @@ interface ContextInterface {
 }
 
 const initialValues: ContextInterface = {
-  isConnected: true,
   upload: () => Promise.reject(),
   getMetadata: () => Promise.reject(),
   getPreview: () => Promise.reject(),
@@ -95,10 +93,8 @@ export function Provider({ children }: Props): ReactElement {
     return `${BEE_HOSTS[hashIndex]}/bzz/${hash}`
   }
 
-  const isConnected = true
-
   return (
-    <Context.Provider value={{ getMetadata, isConnected, upload, getPreview, getChunk, getDownloadLink }}>
+    <Context.Provider value={{ getMetadata, upload, getPreview, getChunk, getDownloadLink }}>
       {children}
     </Context.Provider>
   )


### PR DESCRIPTION
Upload to a gateway node then based on the returned hash select a node for uploading again. Then the hash for downloading can be used to address the same node that uploaded the content, making the download more reliable and quick.