### PR TITLE
feat: make last modified time of uploaded file for metadata

### DIFF
--- a/src/providers/bee.tsx
+++ b/src/providers/bee.tsx
@@ -36,6 +36,8 @@ function hashToIndex(hash: Reference | string) {
 
 export function Provider({ children }: Props): ReactElement {
   const upload = async (file: File, preview?: Blob) => {
+    const lastModified = file.lastModified
+
     const metadata = {
       name: file.name,
       type: file.type,
@@ -44,11 +46,20 @@ export function Provider({ children }: Props): ReactElement {
 
     const metafile = new File([JSON.stringify(metadata)], META_FILE_NAME, {
       type: 'application/json',
+      lastModified,
     })
 
     const files = [file, metafile]
 
-    if (preview) files.push(new File([preview], PREVIEW_FILE_NAME))
+    if (preview) {
+      const previewFile = new File([preview], PREVIEW_FILE_NAME, {
+        lastModified,
+      })
+      files.push(previewFile)
+    }
+
+    // eslint-disable-next-line no-console
+    console.debug({ files })
 
     const hash = await randomBee.uploadFiles(POSTAGE_STAMP, files, { indexDocument: metadata.name })
     const hashIndex = hashToIndex(hash)

--- a/src/providers/bee.tsx
+++ b/src/providers/bee.tsx
@@ -58,9 +58,6 @@ export function Provider({ children }: Props): ReactElement {
       files.push(previewFile)
     }
 
-    // eslint-disable-next-line no-console
-    console.debug({ files })
-
     const hash = await randomBee.uploadFiles(POSTAGE_STAMP, files, { indexDocument: metadata.name })
     const hashIndex = hashToIndex(hash)
 


### PR DESCRIPTION
In this PR the proposed change is to make the last modified time of metadata and preview the same as the uploaded file. This way uploading a file twice results in the same hash reference.

Alternatively I considered use 0 for last modified time to not leak metadata, in that case maybe we could also use 0 for the last modified date for the uploaded file as well.