### PR TITLE
feat: redirect /bzz/<hash> requests to direct download

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -7,8 +7,11 @@ export const ACCESS_HASH = (hash = ':hash'): string => `/access/${hash}`
 export const SHARE = '/share'
 export const TERMS_AND_CONDITIONS = '/termsandconditions'
 
+// ENS compatibility
+export const BZZ = '/bzz/:hash'
+
 // pages
-import { Access, AccessHash, LandingPage, Share, Page404, TermsAndConditions } from './pages'
+import { Access, AccessHash, LandingPage, Share, Page404, TermsAndConditions, RedirectToDownload } from './pages'
 
 const BaseRouter = (): ReactElement => (
   <BrowserRouter>
@@ -18,6 +21,9 @@ const BaseRouter = (): ReactElement => (
       <Route exact path={ACCESS} component={Access} />
       <Route exact path={ACCESS_HASH()} component={AccessHash} />
       <Route exact path={TERMS_AND_CONDITIONS} component={TermsAndConditions} />
+
+      {/* ENS compatibility, redirect to download directly*/}
+      <Route exact path={BZZ} component={RedirectToDownload} />
       <Route path="*" component={Page404} />
     </Switch>
   </BrowserRouter>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,3 +11,4 @@ export const PREVIEW_FILE_NAME = '.swarmgatewaypreview.jpeg'
 const url = window.location.origin
 
 export const GATEWAY_URL = process.env.REACT_APP_GATEWAY_URL || url
+export const DIRECT_DOWNLOAD_URL = process.env.DIRECT_DOWNLOAD_URL || 'https://download.gateway.ethswarm.org/bzz/'

--- a/src/pages/RedirectToDownload.tsx
+++ b/src/pages/RedirectToDownload.tsx
@@ -6,7 +6,7 @@ const RedirectToDownload = (): null => {
 
   // React router can redirect only withing the app itself, that is why we need to assing window.location
   // https://knowbody.github.io/react-router-docs/api/Redirect.html
-  window.location.assign(`${DIRECT_DOWNLOAD_URL}${hash}`)
+  window.location.replace(`${DIRECT_DOWNLOAD_URL}${hash}`)
 
   return null
 }

--- a/src/pages/RedirectToDownload.tsx
+++ b/src/pages/RedirectToDownload.tsx
@@ -1,0 +1,14 @@
+import { useParams } from 'react-router-dom'
+import { DIRECT_DOWNLOAD_URL } from '../constants'
+
+const RedirectToDownload = (): null => {
+  const { hash } = useParams<{ hash: string }>()
+
+  // React router can redirect only withing the app itself, that is why we need to assing window.location
+  // https://knowbody.github.io/react-router-docs/api/Redirect.html
+  window.location.assign(`${DIRECT_DOWNLOAD_URL}${hash}`)
+
+  return null
+}
+
+export default RedirectToDownload

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,5 +4,6 @@ import LandingPage from './LandingPage'
 import Share from './Share'
 import Page404 from './Page404'
 import TermsAndConditions from './TermsAndConditions'
+import RedirectToDownload from './RedirectToDownload'
 
-export { Access, AccessHash, LandingPage, Share, Page404, TermsAndConditions }
+export { Access, AccessHash, LandingPage, Share, Page404, TermsAndConditions, RedirectToDownload }


### PR DESCRIPTION
Fixes #104, fixes #94

Because we want to redirect completely out of the app, we can not use the react router `<Redirect from="/bzz/:hash" to="/access/:hash" />`