### PR TITLE
ci: use PAT token for beeload action

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -64,3 +64,4 @@ jobs:
         uses: ethersphere/beeload-action@v1
         with:
           preview: 'true'
+          token: ${{ secrets.REPO_GHA_PAT }}


### PR DESCRIPTION
This means that bots should be able to have PR previews of their PRs