### PR TITLE
feat: bzz.link support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@ethersphere/bee-js": "3.0.0",
         "@ethersphere/manifest-js": "^1.0.0",
+        "@ethersphere/swarm-cid": "^0.1.0",
         "@material-ui/core": "^4.12.3",
         "browser-image-resizer": "^2.2.1",
         "file-saver": "^2.0.5",
@@ -2158,6 +2159,18 @@
       "integrity": "sha512-ioZH4nxicrCktkA8lvr/82nuqaZt+Itv4TmblvLc0Irz7E8io2cdAHMeVBC636tIvU7pWyP6wYdFXl4wvnFdBQ==",
       "dependencies": {
         "mantaray-js": "^1.0.3"
+      }
+    },
+    "node_modules/@ethersphere/swarm-cid": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersphere/swarm-cid/-/swarm-cid-0.1.0.tgz",
+      "integrity": "sha512-n+n+w5RJBPm7CiPf8TIgNFIRMo4bLh5bYpZxHObgCaxFW8WNZ4UGfqg+qjS/jEr+A3Mmp0lugKDvd8GnfFy7JQ==",
+      "dependencies": {
+        "multiformats": "^9.5.4"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -15777,6 +15790,11 @@
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
+    "node_modules/multiformats": {
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.5.4.tgz",
+      "integrity": "sha512-MFT8e8BOLX7OZKfSBGm13FwYvJVI6MEcZ7hujUCpyJwvYyrC1anul50A0Ee74GdeJ77aYTO6YU1vO+oF8NqSIw=="
+    },
     "node_modules/multimatch": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
@@ -28769,6 +28787,14 @@
         "mantaray-js": "^1.0.3"
       }
     },
+    "@ethersphere/swarm-cid": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@ethersphere/swarm-cid/-/swarm-cid-0.1.0.tgz",
+      "integrity": "sha512-n+n+w5RJBPm7CiPf8TIgNFIRMo4bLh5bYpZxHObgCaxFW8WNZ4UGfqg+qjS/jEr+A3Mmp0lugKDvd8GnfFy7JQ==",
+      "requires": {
+        "multiformats": "^9.5.4"
+      }
+    },
     "@gar/promisify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
@@ -39551,6 +39577,11 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
+    },
+    "multiformats": {
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.5.4.tgz",
+      "integrity": "sha512-MFT8e8BOLX7OZKfSBGm13FwYvJVI6MEcZ7hujUCpyJwvYyrC1anul50A0Ee74GdeJ77aYTO6YU1vO+oF8NqSIw=="
     },
     "multimatch": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@ethersphere/bee-js": "3.0.0",
     "@ethersphere/manifest-js": "^1.0.0",
+    "@ethersphere/swarm-cid": "^0.1.0",
     "@material-ui/core": "^4.12.3",
     "browser-image-resizer": "^2.2.1",
     "file-saver": "^2.0.5",

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,7 @@ The Gateway runs in development mode on [http://localhost:3030/](http://localhos
 
 - `BEE_HOSTS` - comma separated bee API URLs through which the gateway uploads and downloads. The api to upload is
   selected at random while on download the gateway checks all the hosts (defaults to `[http://localhost:1633]`)
+- `BZZ_LINK_DOMAIN` - specifies what domain of Bzz Link should be used (defaults to `bzz.link`)
 - `REACT_APP_POSTAGE_STAMP` - Postage stamp batch ID to be used for uploading (defaults to `00000...00000`
 - `REACT_APP_GATEWAY_URL` - URL on which the gateway is hosted (defaults to current window location)
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,3 +12,4 @@ const url = window.location.origin
 
 export const GATEWAY_URL = process.env.REACT_APP_GATEWAY_URL || url
 export const DIRECT_DOWNLOAD_URL = process.env.DIRECT_DOWNLOAD_URL || 'https://download.gateway.ethswarm.org/bzz/'
+export const BZZ_LINK_DOMAIN = process.env.BZZ_LINK_DOMAIN || 'bzz.link'

--- a/src/pages/AccessHash.tsx
+++ b/src/pages/AccessHash.tsx
@@ -6,6 +6,7 @@ import Typography from '@material-ui/core/Typography'
 import { RefreshCw, ArrowDown, ExternalLink } from 'react-feather'
 import CircularProgress from '@material-ui/core/CircularProgress'
 import { Utils } from '@ethersphere/bee-js'
+import { encodeManifestReference } from '@ethersphere/swarm-cid'
 
 import Header from '../components/Header'
 import Footer from '../components/Footer'
@@ -16,7 +17,7 @@ import FileNotFound from '../components/FileNotFound'
 import UnknownFile from '../components/UnknownFile'
 import LoadingFile from '../components/LoadingFile'
 import InvalidSwarmHash from '../components/InvalidSwarmHash'
-import { DIRECT_DOWNLOAD_URL } from '../constants'
+import { BZZ_LINK_DOMAIN } from '../constants'
 
 import { Context } from '../providers/bee'
 
@@ -36,6 +37,7 @@ const SharePage = (): ReactElement => {
   const classes = useStyles()
 
   const { hash } = useParams<{ hash: string }>()
+  const bzzLink = `https://${encodeManifestReference(hash)}.${BZZ_LINK_DOMAIN}/`
   const { getMetadata, getChunk, download } = useContext(Context)
   const [entries, setEntries] = useState<Record<string, string>>({})
   const [metadata, setMetadata] = useState<Metadata | undefined>()
@@ -111,12 +113,7 @@ const SharePage = (): ReactElement => {
           <div key="center1">
             <AssetPreview previewUri={preview} metadata={metadata} />
             {metadata?.isWebsite && metadata?.hash && (
-              <Button
-                variant="contained"
-                className={classes.button}
-                href={`${DIRECT_DOWNLOAD_URL}${hash}`}
-                target="blank"
-              >
+              <Button variant="contained" className={classes.button} href={bzzLink} target="blank">
                 <ExternalLink strokeWidth={1} />
                 {text.accessHashPage.openWebsite}
                 <ExternalLink style={{ opacity: 0 }} />

--- a/src/pages/Share/Share.tsx
+++ b/src/pages/Share/Share.tsx
@@ -3,7 +3,7 @@ import { makeStyles, createStyles } from '@material-ui/core/styles'
 import IconButton from '@material-ui/core/IconButton'
 import { useHistory } from 'react-router-dom'
 import Button from '@material-ui/core/Button'
-import { ArrowLeft, Clipboard, Check } from 'react-feather'
+import { ArrowLeft, Clipboard, Check, ExternalLink } from 'react-feather'
 import Paper from '@material-ui/core/Paper'
 import Typography from '@material-ui/core/Typography'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
@@ -14,12 +14,14 @@ import Tabs from '../../components/Tabs'
 import Layout from '../../components/Layout'
 
 import * as ROUTES from '../../Routes'
-import { GATEWAY_URL } from '../../constants'
+import { BZZ_LINK_DOMAIN, GATEWAY_URL } from '../../constants'
 
 import text from '../../translations'
+import { encodeManifestReference } from '@ethersphere/swarm-cid'
 
 interface Props {
   uploadReference: string
+  metadata?: Metadata
 }
 
 const useStyles = makeStyles(() =>
@@ -32,9 +34,14 @@ const useStyles = makeStyles(() =>
   }),
 )
 
-const SharePage = ({ uploadReference }: Props): ReactElement => {
+const SharePage = ({ uploadReference, metadata }: Props): ReactElement => {
   const classes = useStyles()
   const history = useHistory()
+  const isWebsite = metadata?.isWebsite
+
+  const bzzLink = `https://${encodeManifestReference(uploadReference)}.${BZZ_LINK_DOMAIN}/`
+  const linkHeader = isWebsite ? 'Bzz Link' : 'Web link'
+  const linkUrl = isWebsite ? bzzLink : `${GATEWAY_URL}${ROUTES.ACCESS_HASH(uploadReference)}`
 
   const [copiedToClipboard, setCopiedToClipboard] = useState<boolean>(false)
   const [activeValue, setActiveValue] = useState<string>(uploadReference)
@@ -71,17 +78,32 @@ const SharePage = ({ uploadReference }: Props): ReactElement => {
           }}
           values={[
             {
-              label: 'Web link',
+              label: linkHeader,
               component: (
-                <Paper
-                  square
-                  elevation={0}
-                  style={{ overflowWrap: 'break-word', textAlign: 'left', padding: 16, margin: 4 }}
-                >
-                  <Typography variant="caption">{`${GATEWAY_URL}${ROUTES.ACCESS_HASH(uploadReference)}`}</Typography>
-                </Paper>
+                <div>
+                  <Paper
+                    square
+                    elevation={0}
+                    style={{ overflowWrap: 'break-word', textAlign: 'left', padding: 16, margin: 4 }}
+                  >
+                    <Typography variant="caption">{linkUrl}</Typography>
+                  </Paper>
+                  {isWebsite && (
+                    <Button
+                      variant="contained"
+                      style={{ margin: 4, width: 'auto' }}
+                      className={classes.button}
+                      href={bzzLink}
+                      target="blank"
+                    >
+                      <ExternalLink strokeWidth={1} />
+                      {text.accessHashPage.openWebsite}
+                      <ExternalLink style={{ opacity: 0 }} />
+                    </Button>
+                  )}
+                </div>
               ),
-              value: `${GATEWAY_URL}${ROUTES.ACCESS_HASH(uploadReference)}`,
+              value: linkUrl,
             },
             {
               label: 'Swarm hash',

--- a/src/pages/Share/index.tsx
+++ b/src/pages/Share/index.tsx
@@ -59,7 +59,7 @@ export default function ShareGeneral(): ReactElement {
 
   if (files.length === 0) return <AddFile setFiles={setFiles} />
 
-  if (uploadReference) return <SharePage uploadReference={uploadReference} />
+  if (uploadReference) return <SharePage uploadReference={uploadReference} metadata={metadata} />
 
   return (
     <Upload

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -119,7 +119,7 @@ const text = {
     downloadAction: 'download',
     downloadingAction: 'downloading...',
     useButtonToDownload: 'Use the button below to download this file.',
-    openWebsite: 'open website',
+    openWebsite: 'open bzz link',
   },
 
   previewDetails: {


### PR DESCRIPTION
Adds Bzz.link support on two places:

 - when you upload a website there is "Bzz link tab" instead of "Web link" with a button to open the bzz.link
 - when you access a website reference then the "Open website" now is "Open bzz link" with the bzz.link