### PR TITLE
fix: use name for the generated zipfile

### DIFF
--- a/src/pages/AccessHash.tsx
+++ b/src/pages/AccessHash.tsx
@@ -74,7 +74,7 @@ const SharePage = (): ReactElement => {
 
   const handleDownload = () => {
     setIsDownloading(true)
-    download(hash, entries).finally(() => setIsDownloading(false))
+    download(hash, entries, metadata).finally(() => setIsDownloading(false))
   }
 
   if (isLoading) {


### PR DESCRIPTION
When I was downloading a website/folder then I got `undefined.zip` zipfile. This fix provides default name.