### PR TITLE
fix: handle non iso-8859-1 in the index document name

### DIFF
--- a/src/providers/bee.tsx
+++ b/src/providers/bee.tsx
@@ -76,19 +76,15 @@ export function Provider({ children }: Props): ReactElement {
       fls.push(previewFile)
     }
 
-    try {
-      const { reference } = await randomBee.uploadFiles(POSTAGE_STAMP, fls, { indexDocument })
-      const hashIndex = hashToIndex(reference)
+    const { reference } = await randomBee.uploadFiles(POSTAGE_STAMP, fls, { indexDocument })
+    const hashIndex = hashToIndex(reference)
 
-      if (hashIndex !== randomIndex) {
-        const bee = new Bee(BEE_HOSTS[hashIndex])
-        await bee.uploadFiles(POSTAGE_STAMP, fls, { indexDocument })
-      }
-
-      return reference
-    } catch (e) {
-      throw e
+    if (hashIndex !== randomIndex) {
+      const bee = new Bee(BEE_HOSTS[hashIndex])
+      await bee.uploadFiles(POSTAGE_STAMP, fls, { indexDocument })
     }
+
+    return reference
   }
 
   const download = async (hash: Reference | string, entries: Record<string, string>, metadata?: Metadata) => {

--- a/src/providers/bee.tsx
+++ b/src/providers/bee.tsx
@@ -47,8 +47,10 @@ function hashToIndex(hash: Reference | string) {
 export function Provider({ children }: Props): ReactElement {
   const upload = async (files: SwarmFile[], metadata: Metadata, preview?: Blob) => {
     const fls = files.map(packageFile) // Apart from packaging, this is needed to not modify the original files array as it can trigger effects
-    const indexDocument =
-      files.length === 1 ? unescape(encodeURIComponent(files[0].name)) : detectIndexHtml(files) || undefined
+    let indexDocument = files.length === 1 ? files[0].name : detectIndexHtml(files) || undefined
+
+    // TODO: Remove once this is fixed in bee-js https://github.com/ethersphere/bee-js/issues/531
+    if (indexDocument) indexDocument = unescape(encodeURIComponent(indexDocument))
     const lastModified = files[0].lastModified
 
     // We want to store only some metadata


### PR DESCRIPTION
Example:
upload a single file containing `02 — Mixed`, the `—` is a non-iso version