### PR TITLE
VOD display

### DIFF
--- a/src/components/FitVideo.tsx
+++ b/src/components/FitVideo.tsx
@@ -1,0 +1,22 @@
+import { createStyles, makeStyles } from '@material-ui/core'
+import { ReactElement } from 'react'
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    video: {
+      width: '100%',
+      height: '100%',
+      objectFit: 'scale-down',
+    },
+  }),
+)
+
+interface VideoProps {
+  src: string | undefined
+}
+
+export function FitVideo(props: VideoProps): ReactElement {
+  const classes = useStyles()
+
+  return <video className={classes.video} src={props.src} controls />
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,8 +5,7 @@ export const POSTAGE_STAMP =
   (process.env.REACT_APP_POSTAGE_STAMP as Reference | undefined) ||
   ('0000000000000000000000000000000000000000000000000000000000000000' as Reference)
 
-export const META_FILE_NAME = '.swarmgatewaymeta.json'
-export const PREVIEW_FILE_NAME = '.swarmgatewaypreview.jpeg'
+export const META_FILE_NAME = 'metadata'
 export const PREVIEW_DIMENSIONS = { maxWidth: 250, maxHeight: 175 }
 
 const url = window.location.origin

--- a/src/pages/Share/Upload.tsx
+++ b/src/pages/Share/Upload.tsx
@@ -56,7 +56,7 @@ const SharePage = ({
 
   if (metadata?.isWebsite) header = text.uploadFile.headerWebsite
 
-  const reachedSizeLimit = Boolean(metadata && metadata?.size > UPLOAD_SIZE_LIMIT)
+  const reachedSizeLimit = Boolean(metadata?.size && metadata.size > UPLOAD_SIZE_LIMIT)
 
   return (
     <Layout

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,16 +1,18 @@
 /// <reference types="react-scripts" />
 
 interface SwarmMetadata {
-  size: number
+  size?: number
   name: string
   type?: string
 }
 
 interface Metadata extends SwarmMetadata {
   type: string
-  isWebsite: boolean
   count?: number
   hash?: string
+  isWebsite?: boolean
+  isVideo?: boolean
+  isImage?: boolean
 }
 
 type FilePath = File & { path?: string; fullPath?: string }

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,5 +1,7 @@
 import { DragEvent } from 'react'
 import { convertSwarmFile } from './SwarmFile'
+import { isSupportedVideoType } from './video'
+import { isSupportedImageType } from './image'
 
 const indexHtmls = ['index.html', 'index.htm']
 
@@ -31,12 +33,14 @@ export function detectIndexHtml(files: SwarmFile[]): string | false {
 
 export function getMetadata(files: SwarmFile[]): Metadata {
   const size = files.reduce((total, item) => total + item.size, 0)
-  const isWebsite = Boolean(detectIndexHtml(files))
   const name = getAssetNameFromFiles(files)
   const type = files.length === 1 ? files[0].type : 'folder'
   const count = files.length
+  const isWebsite = Boolean(detectIndexHtml(files))
+  const isVideo = isSupportedVideoType(type)
+  const isImage = isSupportedImageType(type)
 
-  return { size, name, type, isWebsite, count }
+  return { size, name, type, isWebsite, count, isVideo, isImage }
 }
 
 export function getAssetNameFromFiles(files: SwarmFile[]): string {

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -25,6 +25,28 @@ export function getDimensions(imgWidth: number, imgHeight: number, maxWidth?: nu
   return { width: imgWidth / ratio, height: imgHeight / ratio }
 }
 
+function getAllowedTypes(): string[] {
+  return [
+    'image/bmp',
+    'image/gif',
+    'image/vnd.microsoft.icon',
+    'image/jpeg',
+    'image/png',
+    'image/svg+xml',
+    'image/tiff',
+    'image/webp',
+  ]
+}
+
+/**
+ * Check if the image type is supported
+ *
+ * @param type Image MIME type
+ *
+ * @returns True if the type is supported, false otherwise
+ */
+export const isSupportedImageType = (type: string): boolean => getAllowedTypes().includes(type)
+
 /**
  * Resize image passed to fit in the bounding box defined with maxWidth and maxHeight.
  * Note that one or both of the bounding box dimensions may be omitted
@@ -37,16 +59,7 @@ export function getDimensions(imgWidth: number, imgHeight: number, maxWidth?: nu
  */
 export function resize(file: File, maxWidth?: number, maxHeight?: number): Promise<Blob> {
   return new Promise((resolve, reject) => {
-    const allowedTypes = [
-      'image/bmp',
-      'image/gif',
-      'image/vnd.microsoft.icon',
-      'image/jpeg',
-      'image/png',
-      'image/svg+xml',
-      'image/tiff',
-      'image/webp',
-    ]
+    const allowedTypes = getAllowedTypes()
 
     if (!file.size || !file.type || !allowedTypes.includes(file.type)) return reject('File not supported!')
 

--- a/src/utils/manifest.ts
+++ b/src/utils/manifest.ts
@@ -50,13 +50,19 @@ export class ManifestJs {
   /**
    * Retrieves all paths with the associated hashes from a Swarm manifest
    */
-  public async getHashes(hash: string): Promise<Record<string, string>> {
+  public async getHashes(hash: string, options?: { exclude: string[] }): Promise<Record<string, string>> {
     const data = await this.bee.downloadData(hash)
     const node = new MantarayNode()
     node.deserialize(data)
     await loadAllNodes(this.load.bind(this), node)
-    const result = {}
+    const result: Record<string, string> = {}
     this.extractHashes(result, node)
+
+    if (options?.exclude) {
+      for (const path of options.exclude) {
+        delete result[path]
+      }
+    }
 
     return result
   }

--- a/src/utils/video.ts
+++ b/src/utils/video.ts
@@ -1,0 +1,5 @@
+export function isSupportedVideoType(type: string) {
+  const video = document.createElement('video')
+
+  return video.canPlayType(type) !== ''
+}

--- a/src/utils/video.ts
+++ b/src/utils/video.ts
@@ -1,5 +1,8 @@
 export function isSupportedVideoType(type: string) {
   const video = document.createElement('video')
 
-  return video.canPlayType(type) !== ''
+  const result = video.canPlayType(type)
+  const isDefinitelySupported = result && result !== 'maybe'
+
+  return Boolean(isDefinitelySupported)
 }


### PR DESCRIPTION
# VOD display

## Description
During file upload the user should see a preview about media related files that are html5 supported.

## Related Issues
https://solar-punk.atlassian.net/browse/SPDV-63

## Changes Made
About the new feat
- New FitVideo comp to wrap the styled player
- Utils changes to support image and video types sepparately
- Refactors to align to the new changes on display and support the bee-dashboard as well


## How Has This Been Tested?
I did manual tests. At the file uploader/downloader I tried out a couple of file types to see the previews.
Also, I tried out the hash with bee-dashboard to see if both are compatible.

## Checklist
done - During file upload the user should see a preview about media related files that are html5 supported. Other files don't show any kind of preview.

done - In the Download tab,  for the file preview show a video preview when the format is supported

## Screenshots (if applicable)
Upload:
<img width="1503" alt="Screenshot 2025-01-18 at 18 53 22" src="https://github.com/user-attachments/assets/ea467db4-2c93-435f-bb1b-6fe9e3a88d85" />


Download:
<img width="1503" alt="Screenshot 2025-01-18 at 18 53 35" src="https://github.com/user-attachments/assets/1b3268f8-dfef-442a-9363-12c26e301f92" />

